### PR TITLE
remove NEXT_DISABLE_ESLINT=1 from build script in package.json (did not work)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "NEXT_DISABLE_ESLINT=1 next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
line mentioned did not stop ES Lint errors from running in Vercel

attempting to build again removing this, and configuring Vercel differently to achieve same desired out come