### PR TITLE
modify API urls used with axios to make environment agnostic 

### DIFF
--- a/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/[video_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/[video_id]/page.tsx
@@ -1,55 +1,55 @@
-"use client";
-import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import styles from "./page.module.scss";
-import axios from "axios";
+'use client';
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import styles from './page.module.scss';
+import axios from 'axios';
 
 const url = process.env.NEXT_PUBLIC_APP_URL;
 
 interface Video {
-	created_at: string;
-	description: string;
-	duration: number;
-	id: number;
-	playbackUrl: string;
-	showcase_id: string;
-	thumbnail_url: string;
-	title: string;
-	vimeo_video_id: number;
+  created_at: string;
+  description: string;
+  duration: number;
+  id: number;
+  playbackUrl: string;
+  showcase_id: string;
+  thumbnail_url: string;
+  title: string;
+  vimeo_video_id: number;
 }
 
 export default function SingleVideoPage() {
-	const { video_id } = useParams<{ video_id: string }>();
-	const [video, setVideo] = useState<Video | null>(null);
-	const [loading, setLoading] = useState(true);
+  const { video_id } = useParams<{ video_id: string }>();
+  const [video, setVideo] = useState<Video | null>(null);
+  const [loading, setLoading] = useState(true);
 
-	useEffect(() => {
-		async function getVideo() {
-			try {
-				const response = await axios.get(`${url}/api/videos/${video_id}`);
-				setVideo(response.data);
-				setLoading(false);
-			} catch (error) {
-				console.error(`Unable to retrieve video details from vimeo: ${error}`);
-			}
-		}
+  useEffect(() => {
+    async function getVideo() {
+      try {
+        const response = await axios.get(`/api/videos/${video_id}`);
+        setVideo(response.data);
+        setLoading(false);
+      } catch (error) {
+        console.error(`Unable to retrieve video details from vimeo: ${error}`);
+      }
+    }
 
-		getVideo();
-	}, [video_id]);
+    getVideo();
+  }, [video_id]);
 
-	if (loading) {
-		return <div>Loading video...</div>;
-	}
+  if (loading) {
+    return <div>Loading video...</div>;
+  }
 
-	return (
-		<div className={styles["video-container"]}>
-			<video controls poster={video?.thumbnail_url} className={styles.video}>
-				<source src={`${url}${video?.playbackUrl}`} />
-				Watch the
-				<a
-					href={`${url}${video?.playbackUrl}`}
-				>{`${video?.title} workout video`}</a>
-			</video>
-		</div>
-	);
+  return (
+    <div className={styles['video-container']}>
+      <video controls poster={video?.thumbnail_url} className={styles.video}>
+        <source src={`${url}${video?.playbackUrl}`} />
+        Watch the
+        <a
+          href={`${url}${video?.playbackUrl}`}
+        >{`${video?.title} workout video`}</a>
+      </video>
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/[video_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/[video_id]/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from 'react';
 import styles from './page.module.scss';
 import axios from 'axios';
 
-const url = process.env.NEXT_PUBLIC_APP_URL;
-
 interface Video {
   created_at: string;
   description: string;
@@ -44,10 +42,10 @@ export default function SingleVideoPage() {
   return (
     <div className={styles['video-container']}>
       <video controls poster={video?.thumbnail_url} className={styles.video}>
-        <source src={`${url}${video?.playbackUrl}`} />
+        <source src={`${window.location.origin}${video?.playbackUrl}`} />
         Watch the
         <a
-          href={`${url}${video?.playbackUrl}`}
+          href={`${window.location.origin}${video?.playbackUrl}`}
         >{`${video?.title} workout video`}</a>
       </video>
     </div>

--- a/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
+++ b/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
@@ -13,8 +13,6 @@ import AddToModal from '@/components/dashboard/AddToModal/AddToModal';
 import { Showcase } from '../../../page';
 import { ShowcaseVideo } from '@/components/dashboard/VideoList/VideoList';
 
-const url = process.env.NEXT_PUBLIC_APP_URL;
-
 export default function SingleShowcasePage() {
   const router = useRouter();
   const { showcase_name, showcase_id } = useParams<{

--- a/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
+++ b/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
@@ -1,126 +1,126 @@
-"use client";
-import axios from "axios";
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import Image from "next/image";
-import chevronLeftIcon from "/public/assets/icons/chevron-left.svg";
-import helpIcon from "/public/assets/icons/help.svg";
-import playIcon from "/public/assets/icons/play.svg";
-import clockIcon from "/public/assets/icons/clock.svg";
-import styles from "./page.module.scss";
-import Video from "@/components/dashboard/Video/Video";
-import AddToModal from "@/components/dashboard/AddToModal/AddToModal";
-import { Showcase } from "../../../page";
-import { ShowcaseVideo } from "@/components/dashboard/VideoList/VideoList";
+'use client';
+import axios from 'axios';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import chevronLeftIcon from '/public/assets/icons/chevron-left.svg';
+import helpIcon from '/public/assets/icons/help.svg';
+import playIcon from '/public/assets/icons/play.svg';
+import clockIcon from '/public/assets/icons/clock.svg';
+import styles from './page.module.scss';
+import Video from '@/components/dashboard/Video/Video';
+import AddToModal from '@/components/dashboard/AddToModal/AddToModal';
+import { Showcase } from '../../../page';
+import { ShowcaseVideo } from '@/components/dashboard/VideoList/VideoList';
 
 const url = process.env.NEXT_PUBLIC_APP_URL;
 
 export default function SingleShowcasePage() {
-	const router = useRouter();
-	const { showcase_name, showcase_id } = useParams<{
-		showcase_name: string;
-		showcase_id: string;
-	}>();
-	const [loading, setLoading] = useState(true);
-	const [showcase, setShowCase] = useState<Showcase | null>(null);
-	const [showcaseVideos, setShowCaseVideos] = useState<ShowcaseVideo[]>([]);
-	const [isModalOpen, setIsModalOpen] = useState(false);
-	const showcaseName = showcase_name.replaceAll("-", " ");
+  const router = useRouter();
+  const { showcase_name, showcase_id } = useParams<{
+    showcase_name: string;
+    showcase_id: string;
+  }>();
+  const [loading, setLoading] = useState(true);
+  const [showcase, setShowCase] = useState<Showcase | null>(null);
+  const [showcaseVideos, setShowCaseVideos] = useState<ShowcaseVideo[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const showcaseName = showcase_name.replaceAll('-', ' ');
 
-	useEffect(() => {
-		async function getShowcaseVideos() {
-			try {
-				const response = await axios.get(`${url}/api/showcases/${showcase_id}`);
-				setShowCase(response.data.showcase);
-				setShowCaseVideos(response.data.videos);
-				setLoading(false);
-			} catch (error) {
-				console.error(
-					`Unable to retrieve showcase videos from Vimeo: ${error}`
-				);
-			}
-		}
+  useEffect(() => {
+    async function getShowcaseVideos() {
+      try {
+        const response = await axios.get(`/api/showcases/${showcase_id}`);
+        setShowCase(response.data.showcase);
+        setShowCaseVideos(response.data.videos);
+        setLoading(false);
+      } catch (error) {
+        console.error(
+          `Unable to retrieve showcase videos from Vimeo: ${error}`
+        );
+      }
+    }
 
-		getShowcaseVideos();
-	}, [showcase_id]);
+    getShowcaseVideos();
+  }, [showcase_id]);
 
-	if (loading) {
-		return <div>Loading videos for {showcaseName}...</div>;
-	}
+  if (loading) {
+    return <div>Loading videos for {showcaseName}...</div>;
+  }
 
-	return (
-		<>
-			<div className={styles.header}>
-				<div className={styles["title-container"]}>
-					<button
-						className={styles.header__button}
-						onClick={() => router.back()}
-					>
-						<Image
-							src={chevronLeftIcon}
-							alt="A left Chevron icon to navigate back"
-							className={styles.hero__icon}
-						/>
-					</button>
-					<h1 className={styles.header__title}>{showcaseName}</h1>
-				</div>
-				<button className={styles.header__button}>
-					<Image
-						src={helpIcon}
-						alt="The Help Icon"
-						className={styles.hero__icon}
-					/>
-				</button>
-			</div>
-			<div className={styles.hero}>
-				<div className={styles["hero__image-container"]}>
-					{/* <Image
+  return (
+    <>
+      <div className={styles.header}>
+        <div className={styles['title-container']}>
+          <button
+            className={styles.header__button}
+            onClick={() => router.back()}
+          >
+            <Image
+              src={chevronLeftIcon}
+              alt="A left Chevron icon to navigate back"
+              className={styles.hero__icon}
+            />
+          </button>
+          <h1 className={styles.header__title}>{showcaseName}</h1>
+        </div>
+        <button className={styles.header__button}>
+          <Image
+            src={helpIcon}
+            alt="The Help Icon"
+            className={styles.hero__icon}
+          />
+        </button>
+      </div>
+      <div className={styles.hero}>
+        <div className={styles['hero__image-container']}>
+          {/* <Image
 						src={showcase.thumbnail_url}
 						alt={`Thumbnail image for the ${showcaseName} workout`}
 						width={0}
 						height={0}
 						className={styles.hero__image}
 					/> */}
-				</div>
-				<div className={styles.hero__info}>
-					<span>
-						<Image
-							src={playIcon}
-							alt="A play icon to symbolize number of videos in the workout"
-							className={styles.hero__icon}
-						/>
-						{showcaseVideos.length} videos
-					</span>
-					<span>
-						<Image
-							src={clockIcon}
-							alt="A clock icon to symbolize the duration of this workout"
-							className={styles.hero__icon}
-						/>
-						{`[duration]`} mins
-					</span>
-				</div>
-				<p className={styles.hero__description}>
-					{showcase?.description ||
-						"[Description goes here but it is currently empty]"}
-				</p>
-			</div>
-			<ul className={styles.list} role="list">
-				{showcaseVideos.map((video) => {
-					return (
-						<li key={video.id}>
-							<Video
-								showcaseVideo={video}
-								display="row"
-								isModalOpen={isModalOpen}
-								setIsModalOpen={setIsModalOpen}
-								path={`/dashboard/${showcase_name}/${showcase_id}/videos`}
-							/>
-						</li>
-					);
-				})}
-			</ul>
-			<AddToModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
-		</>
-	);
+        </div>
+        <div className={styles.hero__info}>
+          <span>
+            <Image
+              src={playIcon}
+              alt="A play icon to symbolize number of videos in the workout"
+              className={styles.hero__icon}
+            />
+            {showcaseVideos.length} videos
+          </span>
+          <span>
+            <Image
+              src={clockIcon}
+              alt="A clock icon to symbolize the duration of this workout"
+              className={styles.hero__icon}
+            />
+            {`[duration]`} mins
+          </span>
+        </div>
+        <p className={styles.hero__description}>
+          {showcase?.description ||
+            '[Description goes here but it is currently empty]'}
+        </p>
+      </div>
+      <ul className={styles.list} role="list">
+        {showcaseVideos.map((video) => {
+          return (
+            <li key={video.id}>
+              <Video
+                showcaseVideo={video}
+                display="row"
+                isModalOpen={isModalOpen}
+                setIsModalOpen={setIsModalOpen}
+                path={`/dashboard/${showcase_name}/${showcase_id}/videos`}
+              />
+            </li>
+          );
+        })}
+      </ul>
+      <AddToModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+    </>
+  );
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -6,8 +6,6 @@ import DashboardPageContent from '@/components/dashboard/DashboardPageContent/Da
 import styles from './page.module.scss';
 import AddToModal from '@/components/dashboard/AddToModal/AddToModal';
 
-const url = process.env.NEXT_PUBLIC_APP_URL;
-
 export interface Showcase {
   id: number;
   vimeo_showcase_id: string;

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,132 +1,132 @@
-"use client";
+'use client';
 
-import { Suspense, useEffect, useState } from "react";
-import axios from "axios";
-import DashboardPageContent from "@/components/dashboard/DashboardPageContent/DashboardPageContent";
-import styles from "./page.module.scss";
-import AddToModal from "@/components/dashboard/AddToModal/AddToModal";
+import { Suspense, useEffect, useState } from 'react';
+import axios from 'axios';
+import DashboardPageContent from '@/components/dashboard/DashboardPageContent/DashboardPageContent';
+import styles from './page.module.scss';
+import AddToModal from '@/components/dashboard/AddToModal/AddToModal';
 
 const url = process.env.NEXT_PUBLIC_APP_URL;
 
 export interface Showcase {
-	id: number;
-	vimeo_showcase_id: string;
-	name: "string";
-	description: string;
-	thumbnail_url: string;
-	vimeo_link: string;
-	created_at: string;
+  id: number;
+  vimeo_showcase_id: string;
+  name: 'string';
+  description: string;
+  thumbnail_url: string;
+  vimeo_link: string;
+  created_at: string;
 }
 
 export default function DashboardPage() {
-	const [showcases, setShowcases] = useState<Showcase[]>([]);
-	const [isSelected, setIsSelected] = useState({
-		element: true,
-		program: false,
-	});
-	const [isModalOpen, setIsModalOpen] = useState(false);
+  const [showcases, setShowcases] = useState<Showcase[]>([]);
+  const [isSelected, setIsSelected] = useState({
+    element: true,
+    program: false,
+  });
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-	function handleSelect(selected: boolean) {
-		if (!selected) {
-			setIsSelected({
-				element: !isSelected.element,
-				program: !isSelected.program,
-			});
-		}
-	}
+  function handleSelect(selected: boolean) {
+    if (!selected) {
+      setIsSelected({
+        element: !isSelected.element,
+        program: !isSelected.program,
+      });
+    }
+  }
 
-	useEffect(() => {
-		async function getShowcases() {
-			try {
-				const response = await axios.get(`${url}/api/showcases`);
-				setShowcases(
-					response.data.showcases.filter(
-						(video: Showcase) =>
-							!video.name.toLowerCase().includes("body burning")
-					)
-				);
-			} catch (error) {
-				console.error(
-					`Unable to retrieve showcase videos from Vimeo: ${error}`
-				);
-			}
-		}
+  useEffect(() => {
+    async function getShowcases() {
+      try {
+        const response = await axios.get(`/api/showcases`);
+        setShowcases(
+          response.data.showcases.filter(
+            (video: Showcase) =>
+              !video.name.toLowerCase().includes('body burning')
+          )
+        );
+      } catch (error) {
+        console.error(
+          `Unable to retrieve showcase videos from Vimeo: ${error}`
+        );
+      }
+    }
 
-		getShowcases();
-	}, []);
+    getShowcases();
+  }, []);
 
-	//filter showcase videos by element or prescription programs
-	const filteredShowcases = showcases.filter((video: Showcase) =>
-		isSelected.program
-			? video.name.toLowerCase().includes("prescription")
-			: !video.name.toLowerCase().includes("prescription")
-	);
+  //filter showcase videos by element or prescription programs
+  const filteredShowcases = showcases.filter((video: Showcase) =>
+    isSelected.program
+      ? video.name.toLowerCase().includes('prescription')
+      : !video.name.toLowerCase().includes('prescription')
+  );
 
-	filteredShowcases.sort((a, b) => (a.name > b.name ? 1 : -1));
+  filteredShowcases.sort((a, b) => (a.name > b.name ? 1 : -1));
 
-	return (
-		<Suspense fallback={<div>Loading dashboard...</div>}>
-			<div className={styles["tab-container"]}>
-				<ul className={styles.tabContent} role="tablist" tabIndex={0}>
-					<li
-						role="tab"
-						tabIndex={0}
-						id="element-tab"
-						aria-selected={isSelected.element}
-						aria-controls="element-panel"
-						className={`${styles.tab} ${
-							isSelected.element ? styles["tab--selected"] : ""
-						}`}
-						onClick={() => {
-							handleSelect(isSelected.element);
-						}}
-					>
-						elements
-					</li>
-					<li
-						role="tab"
-						tabIndex={0}
-						id="program-tab"
-						aria-selected={isSelected.program}
-						aria-controls="program-panel"
-						className={`${styles.tab} ${
-							isSelected.program ? styles["tab--selected"] : ""
-						}`}
-						onClick={() => {
-							handleSelect(isSelected.program);
-						}}
-					>
-						prescription programs
-					</li>
-				</ul>
-			</div>
-			<div
-				id="element-panel"
-				role="tabpanel"
-				aria-labelledby="element-tab"
-				hidden={!isSelected.element}
-			>
-				<DashboardPageContent
-					showcases={filteredShowcases}
-					type="element"
-					isModalOpen={isModalOpen}
-					setIsModalOpen={setIsModalOpen}
-				/>
-			</div>
-			<div
-				id="program-panel"
-				role="tabpanel"
-				aria-labelledby="program-tab"
-				hidden={!isSelected.program}
-			>
-				<DashboardPageContent
-					showcases={filteredShowcases}
-					type="program"
-					isModalOpen={isModalOpen}
-					setIsModalOpen={setIsModalOpen}
-				/>
-			</div>
-			<AddToModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
-		</Suspense>
-	);
+  return (
+    <Suspense fallback={<div>Loading dashboard...</div>}>
+      <div className={styles['tab-container']}>
+        <ul className={styles.tabContent} role="tablist" tabIndex={0}>
+          <li
+            role="tab"
+            tabIndex={0}
+            id="element-tab"
+            aria-selected={isSelected.element}
+            aria-controls="element-panel"
+            className={`${styles.tab} ${
+              isSelected.element ? styles['tab--selected'] : ''
+            }`}
+            onClick={() => {
+              handleSelect(isSelected.element);
+            }}
+          >
+            elements
+          </li>
+          <li
+            role="tab"
+            tabIndex={0}
+            id="program-tab"
+            aria-selected={isSelected.program}
+            aria-controls="program-panel"
+            className={`${styles.tab} ${
+              isSelected.program ? styles['tab--selected'] : ''
+            }`}
+            onClick={() => {
+              handleSelect(isSelected.program);
+            }}
+          >
+            prescription programs
+          </li>
+        </ul>
+      </div>
+      <div
+        id="element-panel"
+        role="tabpanel"
+        aria-labelledby="element-tab"
+        hidden={!isSelected.element}
+      >
+        <DashboardPageContent
+          showcases={filteredShowcases}
+          type="element"
+          isModalOpen={isModalOpen}
+          setIsModalOpen={setIsModalOpen}
+        />
+      </div>
+      <div
+        id="program-panel"
+        role="tabpanel"
+        aria-labelledby="program-tab"
+        hidden={!isSelected.program}
+      >
+        <DashboardPageContent
+          showcases={filteredShowcases}
+          type="program"
+          isModalOpen={isModalOpen}
+          setIsModalOpen={setIsModalOpen}
+        />
+      </div>
+      <AddToModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+    </Suspense>
+  );
 }

--- a/src/components/dashboard/VideoList/VideoList.tsx
+++ b/src/components/dashboard/VideoList/VideoList.tsx
@@ -1,99 +1,99 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { useRouter } from "next/navigation";
-import { Showcase } from "src/app/(dashboard)/dashboard/page";
-import Video from "../Video/Video";
-import styles from "./VideoList.module.scss";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useRouter } from 'next/navigation';
+import { Showcase } from 'src/app/(dashboard)/dashboard/page';
+import Video from '../Video/Video';
+import styles from './VideoList.module.scss';
 
 const url = process.env.NEXT_PUBLIC_APP_URL;
 
 interface VideoListProps {
-	video: Showcase;
-	isModalOpen: boolean;
-	setIsModalOpen: (arg1: boolean) => void;
+  video: Showcase;
+  isModalOpen: boolean;
+  setIsModalOpen: (arg1: boolean) => void;
 }
 
 export interface ShowcaseVideo {
-	id: number;
-	vimeo_video_id: string;
-	title: "string";
-	description: string;
-	duration: number;
-	position: number;
-	thumbnail_url: string;
-	created_at: string;
+  id: number;
+  vimeo_video_id: string;
+  title: 'string';
+  description: string;
+  duration: number;
+  position: number;
+  thumbnail_url: string;
+  created_at: string;
 }
 
 export default function VideoList({
-	video,
-	isModalOpen,
-	setIsModalOpen,
+  video,
+  isModalOpen,
+  setIsModalOpen,
 }: VideoListProps) {
-	const router = useRouter();
-	const [showcaseVideos, setShowCaseVideos] = useState<ShowcaseVideo[]>([]);
-	const [isLoading, setIsLoading] = useState(true);
-	const routeName = video.name
-		.toLowerCase()
-		.replace(/\s+/g, "-") //replace spaces with hyphens for better readability
-		.replace(/[%\.]/g, ""); //replace %  as it causes a Bad Request Error
+  const router = useRouter();
+  const [showcaseVideos, setShowCaseVideos] = useState<ShowcaseVideo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const routeName = video.name
+    .toLowerCase()
+    .replace(/\s+/g, '-') //replace spaces with hyphens for better readability
+    .replace(/[%\.]/g, ''); //replace %  as it causes a Bad Request Error
 
-	useEffect(() => {
-		async function getShowcaseVideos() {
-			try {
-				const response = await axios.get(
-					`${url}/api/showcases/${video.vimeo_showcase_id}`
-				);
-				setShowCaseVideos(response.data.videos);
-				setIsLoading(false);
-			} catch (error) {
-				console.error(
-					`Unable to retrieve showcase videos from Vimeo: ${error}`
-				);
-			}
-		}
+  useEffect(() => {
+    async function getShowcaseVideos() {
+      try {
+        const response = await axios.get(
+          `/api/showcases/${video.vimeo_showcase_id}`
+        );
+        setShowCaseVideos(response.data.videos);
+        setIsLoading(false);
+      } catch (error) {
+        console.error(
+          `Unable to retrieve showcase videos from Vimeo: ${error}`
+        );
+      }
+    }
 
-		getShowcaseVideos();
-	}, []);
+    getShowcaseVideos();
+  }, []);
 
-	if (isLoading) {
-		return <div>List of videos is loading...</div>;
-	}
+  if (isLoading) {
+    return <div>List of videos is loading...</div>;
+  }
 
-	function handleShowVideoList() {
-		router.push(`/dashboard/${routeName}/${video.vimeo_showcase_id}/videos`);
-	}
+  function handleShowVideoList() {
+    router.push(`/dashboard/${routeName}/${video.vimeo_showcase_id}/videos`);
+  }
 
-	return (
-		<section className={styles.container}>
-			<div className={styles.header}>
-				<header>
-					<h2 className={styles.title}>{video.name.toLowerCase()}</h2>
-					<p className={styles.description}>
-						{video.description ||
-							"[Description goes here but it is currently empty]"}
-					</p>
-				</header>
-				<button className={styles.button} onClick={handleShowVideoList}>
-					View all
-				</button>
-			</div>
-			<ul className={styles.list}>
-				{showcaseVideos.map((showcaseVideo) => {
-					return (
-						<li key={showcaseVideo.id}>
-							<Video
-								showcaseVideo={showcaseVideo}
-								display="column"
-								isModalOpen={isModalOpen}
-								setIsModalOpen={setIsModalOpen}
-								path={`/dashboard/${routeName}/${video.vimeo_showcase_id}/videos`}
-							/>
-						</li>
-					);
-				})}
-			</ul>
-		</section>
-	);
+  return (
+    <section className={styles.container}>
+      <div className={styles.header}>
+        <header>
+          <h2 className={styles.title}>{video.name.toLowerCase()}</h2>
+          <p className={styles.description}>
+            {video.description ||
+              '[Description goes here but it is currently empty]'}
+          </p>
+        </header>
+        <button className={styles.button} onClick={handleShowVideoList}>
+          View all
+        </button>
+      </div>
+      <ul className={styles.list}>
+        {showcaseVideos.map((showcaseVideo) => {
+          return (
+            <li key={showcaseVideo.id}>
+              <Video
+                showcaseVideo={showcaseVideo}
+                display="column"
+                isModalOpen={isModalOpen}
+                setIsModalOpen={setIsModalOpen}
+                path={`/dashboard/${routeName}/${video.vimeo_showcase_id}/videos`}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
 }

--- a/src/components/dashboard/VideoList/VideoList.tsx
+++ b/src/components/dashboard/VideoList/VideoList.tsx
@@ -7,8 +7,6 @@ import { Showcase } from 'src/app/(dashboard)/dashboard/page';
 import Video from '../Video/Video';
 import styles from './VideoList.module.scss';
 
-const url = process.env.NEXT_PUBLIC_APP_URL;
-
 interface VideoListProps {
   video: Showcase;
   isModalOpen: boolean;


### PR DESCRIPTION
**1st commit**

-Updated current API call to not include base url since they're being served by Next.js app API
   ex. axios.get('/api/showcases')
   
 -this should be best practice for Next.js app serving API data
 
 -allows for making app work in development on mobile device (otherwise axios throws CORS error when base url is localhost:3000 but making API cal from http://192.168.1.152:3000 on mobile device)
 
 
 **2nd commit**
 -removes unnecessary variable assignment to base url from .env file for PUBLIC_APP_URL across most recent video fiels:
     sp. this line:   const url = process.env.NEXT_PUBLIC_APP_URL;
     
- <source> updated so base url becomes window.location.origin (so will work regardless of device and can be tested locally     