### PR TITLE
update included files to now manage adding a video to playlist with real_vimeo_video_id

### DIFF
--- a/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
+++ b/src/app/(dashboard)/dashboard/[showcase_name]/[showcase_id]/videos/page.tsx
@@ -19,6 +19,7 @@ interface Chapter {
   duration: number | null;
   showcase_id: number;
   continuous_vimeo_id: string;
+  real_vimeo_video_id: string;
 }
 
 export default function SingleShowcasePage() {
@@ -95,6 +96,7 @@ export default function SingleShowcasePage() {
       ...matchingVideo,
       title: chapter.title, // Use chapter title
       start_time: chapter.start_time,
+      real_vimeo_video_id: chapter.real_vimeo_video_id,
     };
   });
 

--- a/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
@@ -169,6 +169,7 @@ export default function PlayerPage() {
                   item.description || `Starts at ${item.start_time}s`,
                 duration: item.duration || 0,
                 vimeo_video_id: String(continuous_vimeo_id),
+                real_vimeo_video_id: item.real_vimeo_video_id,
                 created_at: item.created_at || "",
                 showcase_id: showcase_id || "",
                 start_time: item.start_time,

--- a/src/components/pages/dashboard/VideoList/VideoList.tsx
+++ b/src/components/pages/dashboard/VideoList/VideoList.tsx
@@ -17,6 +17,7 @@ export interface ShowcaseVideo {
   created_at: string;
   showcase_id: string;
   start_time: any;
+  real_vimeo_video_id: string;
 }
 
 interface Chapter {
@@ -26,6 +27,7 @@ interface Chapter {
   duration: number | null;
   showcase_id: number;
   continuous_vimeo_id: string;
+  real_vimeo_video_id: string;
 }
 
 interface VideoListProps {
@@ -127,6 +129,7 @@ export default function VideoList({ video }: VideoListProps) {
       ...matchingVideo,
       title: chapter.title,
       start_time: chapter.start_time,
+      real_vimeo_video_id: chapter.real_vimeo_video_id,
     };
   });
 


### PR DESCRIPTION
-side note, name of branch not reflective of updates.

-backend database updated to include field on chapters table 'real_vimeo_video_id'

-seeding script updated for chapters to cross reference chapter titles for continuous video with title of actual individual video titles those chapters mimic, then store the real_vimeo_video_id as a field so actual individual video can be stored when adding to a custom playlist

-frontend files in this PR updates to now use real_vimeo_video_id to appropriately store correct individual video in DB on POST request to add video to playlist