### PR TITLE
updated stripe checkout API route to use env. variables for 'trial_period_days' and 'price'

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -67,12 +67,12 @@ export async function POST(req: NextRequest) {
       customer: stripeCustomerId,
       line_items: [
         {
-          price: "plan_Pr3EoR7dvIAlN7", // Replace with Stripe Price ID or plan ID
+          price: process.env.STRIPE_MONTHLY_PLAN_KEY, // Replace with Stripe Price ID or plan ID
           quantity: 1,
         },
       ],
       subscription_data: {
-        trial_period_days: 1,
+        trial_period_days: Number(process.env.STRIPE_TRIAL_DURATION),
       },
       success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?refresh=true&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,


### PR DESCRIPTION
-in stripe checkoutAPI route, updated stipe.checkout.sessions.create() function to utilize .env variables for  'trial_period_days' and 'price' properties
-Vercel updated with these .env variables

--purpose is that production environment should only use details specific to Stripe production plan, and other environments can use test trial period and test plan