### PR TITLE
udpate app/layout pages to ensure google analytics is not tracking develop envrironment

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const isProd = process.env.NODE_ENV === "production";
+  // modify if site needs to track subdomains in the future
+  const isProd = process.env.NEXT_PUBLIC_APP_URL === "https://systemofsilk.com";
+
   return (
     <html lang="en">
       <head>


### PR DESCRIPTION
-discovered google tracking code in deployed development environment
-made udpate in code to prevent this (should ensure tracking code only renders on live site <head> code

