### PR TITLE
Fix check/update db (DB updated to include missing videos CC Rd. 9 and LLB Rd. 4)

### DIFF
--- a/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { useSearchParams, useParams, useRouter } from "next/navigation";
 import backArrowIcon from "/public/assets/icons/arrow-left.svg";
 import Player from "@vimeo/player";
@@ -43,6 +43,7 @@ export default function PlayerPage() {
     ? parseInt(searchParams.get("start_time") as string, 10)
     : 0;
   const autoplay = searchParams.get("autoplay") === "1";
+
   const [continuousVideo, setContinuousVideo] = useState({
     continuous_video_id: "",
     continuous_video_title: "",
@@ -58,6 +59,52 @@ export default function PlayerPage() {
 
   const playerContainerRef = useRef<HTMLDivElement | null>(null);
   const vimeoPlayerRef = useRef<Player | null>(null);
+
+  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
+  const thumbnailMap = useMemo(() => {
+    const m = new Map<string, VideoThumbnails>();
+    videoThumbnails.forEach((item) => {
+      const key = String(item?.real_vimeo_video_id ?? "").trim();
+      if (key) m.set(key, item);
+    });
+    return m;
+  }, [videoThumbnails]);
+
+  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
+  const mergedData: VideoItem[] = useMemo(() => {
+    return chapters
+      .slice()
+      .sort((a, b) => a.start_time - b.start_time)
+      .map((chapter) => {
+        const chapterKey = String(chapter.real_vimeo_video_id ?? "").trim();
+        const meta = chapterKey ? thumbnailMap.get(chapterKey) : undefined;
+
+        return {
+          ...chapter,
+          ...(meta ?? {}),
+          id: chapter.id, // prevent meta.id from overwriting chapters.id
+          title: chapter.title || meta?.corresponding_video_title || "Untitled",
+          thumbnail_url: meta?.thumbnail_url?.startsWith("http")
+            ? meta.thumbnail_url
+            : "/assets/images/default-thumbnail.jpg",
+          video_description:
+            meta?.video_description || continuousVideo.video_description || "",
+          real_vimeo_video_id: String(
+            chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
+          ).trim(),
+          chapter_id: meta?.chapter_id ?? "",
+          chapter_title: meta?.chapter_title ?? "",
+          corresponding_video_title: meta?.corresponding_video_title ?? "",
+          created_at: meta?.created_at ?? "",
+        };
+      });
+  }, [chapters, thumbnailMap, continuousVideo.video_description]);
+
+  // Keep latest mergedData accessible to the Vimeo event handler (avoid stale closure)
+  const mergedDataRef = useRef<VideoItem[]>([]);
+  useEffect(() => {
+    mergedDataRef.current = mergedData;
+  }, [mergedData]);
 
   //Check if the screen is a desktop
   useEffect(() => {
@@ -93,7 +140,7 @@ export default function PlayerPage() {
       }
     }
     fetchData();
-  }, [continuous_vimeo_id]);
+  }, [continuous_vimeo_id, router]);
 
   //  Fetch video thumbnails
   useEffect(() => {
@@ -120,6 +167,8 @@ export default function PlayerPage() {
   useEffect(() => {
     if (!playerContainerRef.current || vimeoPlayerRef.current) return;
 
+    let isMounted = true;
+
     const player = new Player(playerContainerRef.current, {
       id: parseInt(continuous_vimeo_id, 10),
       responsive: true,
@@ -128,30 +177,64 @@ export default function PlayerPage() {
 
     vimeoPlayerRef.current = player;
 
-    player.ready().then(async () => {
-      setPlayerReady(true);
-      if (initialStartTime > 0) {
-        await player.setCurrentTime(initialStartTime).catch(console.error);
-        try {
-          await player.play();
-        } catch (err) {
-          console.warn("Autoplay blocked (expected in some browsers):", err);
-        }
-      }
+    const onTimeUpdate = (data: { seconds: number }) => {
+      const list = mergedDataRef.current;
+      if (!list.length) return;
 
-      player.on("timeupdate", (data) => {
-        const currentTime = data.seconds;
-        const index =
-          chapters.filter((c) => c.start_time <= currentTime).length - 1;
-        if (index !== activeChapterIndex) setActiveChapterIndex(index);
+      const t = data.seconds;
+
+      let idx = list.findIndex((c, i) => {
+        const start = c.start_time;
+        const nextStart = list[i + 1]?.start_time ?? Number.POSITIVE_INFINITY;
+        return t >= start && t < nextStart;
       });
-    });
+
+      if (idx === -1) idx = 0;
+      setActiveChapterIndex((prev) => (prev === idx ? prev : idx));
+    };
+
+    player
+      .ready()
+      .then(async () => {
+        if (!isMounted) return;
+
+        setPlayerReady(true);
+
+        if (initialStartTime > 0) {
+          await player.setCurrentTime(initialStartTime).catch(console.error);
+          try {
+            await player.play();
+          } catch (err) {
+            console.warn("Autoplay blocked (expected in some browsers):", err);
+          }
+        }
+
+        player.on("timeupdate", onTimeUpdate);
+      })
+      .catch((err) => {
+        const msg = String(err?.message ?? err);
+        if (msg.includes("Unknown player") || msg.includes("unloaded")) return;
+        console.error("Vimeo player ready() failed:", err);
+      });
 
     return () => {
-      player.destroy().catch(console.error);
+      isMounted = false;
+
+      try {
+        player.off("timeupdate", onTimeUpdate);
+      } catch {
+        // ignore
+      }
+
+      player.destroy().catch((err) => {
+        const msg = String(err?.message ?? err);
+        if (msg.includes("Unknown player") || msg.includes("unloaded")) return;
+        console.error(err);
+      });
+
       vimeoPlayerRef.current = null;
     };
-  }, [continuous_vimeo_id, chapters, initialStartTime]);
+  }, [continuous_vimeo_id, initialStartTime]);
 
   //  Autoplay logic
   useEffect(() => {
@@ -166,7 +249,7 @@ export default function PlayerPage() {
         console.warn("Autoplay blocked by browser:", err);
       });
     }
-  }, [autoplay, playerReady, chapters]);
+  }, [autoplay, playerReady, chapters, initialStartTime]);
 
   //  Clean up injected Vimeo styles
   useEffect(() => {
@@ -194,8 +277,8 @@ export default function PlayerPage() {
   useEffect(() => {
     if (
       isDesktop &&
-      activeChapterIndex &&
-      activeChapterIndex > -1 &&
+      typeof activeChapterIndex === "number" &&
+      activeChapterIndex >= 0 &&
       scrollableContainerRef.current
     ) {
       const activeChapter = Array.from(
@@ -206,66 +289,9 @@ export default function PlayerPage() {
     }
   }, [activeChapterIndex, isDesktop]);
 
-  // Check for duplicate real_vimeo_video_id in videoThumbnails
-  useEffect(() => {
-    if (!videoThumbnails.length) return;
+  // NOTE: removed debug-only duplicate logging for production cleanliness
 
-    const counts = new Map<string, number>();
-    for (const v of videoThumbnails) {
-      const key = String(v.real_vimeo_video_id ?? "");
-      if (!key) continue;
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-
-    const dups = Array.from(counts.entries()).filter(([, n]) => n > 1);
-    if (dups.length) {
-      console.warn(
-        "[PlayerPage] Duplicate real_vimeo_video_id(s) in videoThumbnails:",
-        dups
-      );
-      console.warn(
-        "[PlayerPage] Example duplicated rows:",
-        videoThumbnails.filter(
-          (v) => String(v.real_vimeo_video_id) === dups[0][0]
-        )
-      );
-    }
-  }, [videoThumbnails]);
-
-  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
-  const thumbnailMap = new Map<string, VideoThumbnails>();
-  videoThumbnails.forEach((item) => {
-    if (item?.real_vimeo_video_id) {
-      thumbnailMap.set(String(item.real_vimeo_video_id), item);
-    }
-  });
-
-  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
-  const mergedData: VideoItem[] = chapters.map((chapter) => {
-    const meta = chapter.real_vimeo_video_id
-      ? thumbnailMap.get(String(chapter.real_vimeo_video_id))
-      : undefined;
-
-    return {
-      ...chapter,
-      ...(meta ?? {}),
-      title: chapter.title || meta?.corresponding_video_title || "Untitled",
-      thumbnail_url: meta?.thumbnail_url?.startsWith("http")
-        ? meta.thumbnail_url
-        : "/assets/images/default-thumbnail.jpg",
-      video_description:
-        meta?.video_description || continuousVideo.video_description || "",
-      real_vimeo_video_id: String(
-        chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
-      ),
-      chapter_id: meta?.chapter_id ?? "",
-      chapter_title: meta?.chapter_title ?? "",
-      corresponding_video_title: meta?.corresponding_video_title ?? "",
-      created_at: meta?.created_at ?? "",
-    };
-  });
-
-  const handleChapterClick = (
+  const handleChapterClick = async (
     chapter: VideoItem,
     index: number,
     event: React.MouseEvent<HTMLLIElement>
@@ -279,13 +305,22 @@ export default function PlayerPage() {
       return;
     }
 
-    if (vimeoPlayerRef.current) {
-      vimeoPlayerRef.current.setCurrentTime(chapter.start_time).then(() => {
-        vimeoPlayerRef.current?.play().catch((err) => {
-          console.warn("Autoplay blocked on chapter click:", err);
-        });
-        setActiveChapterIndex(index);
+    const player = vimeoPlayerRef.current;
+    if (!player) return;
+
+    // Optimistically set highlight immediately
+    setActiveChapterIndex(index);
+
+    try {
+      // Nudge forward by a tiny epsilon so boundary conditions won't snap to prior chapter
+      const target = Math.max(0, Number(chapter.start_time) + 0.01);
+      await player.setCurrentTime(target);
+
+      player.play().catch((err) => {
+        console.warn("Autoplay blocked on chapter click:", err);
       });
+    } catch (e) {
+      console.error("Failed to seek to chapter:", e);
     }
   };
 
@@ -308,15 +343,12 @@ export default function PlayerPage() {
       fifteen: "15",
     };
 
-    // Normalize the input by trimming and converting to lowercase
     const normalizedTitle = continuousTitle.trim().toLowerCase();
 
-    // Check for 'Silk Continuous' using lowercase comparison
     if (normalizedTitle.includes("silk continuous")) {
       return continuousTitle.replace(/silk continuous/i, "").trim();
     }
 
-    // Check for 'Silk Workout' using lowercase comparison
     if (normalizedTitle.includes("silk workout")) {
       const words = continuousTitle
         .replace(/silk workout/i, "")
@@ -331,13 +363,12 @@ export default function PlayerPage() {
       return `100% Prescription Program ${words.join(" ")}`;
     }
 
-    // log in non production mode, title that don't need formatting
-    if (process.env.NEXT_PUBLIC_APP_URL !== "https://systemofsilk.com") {
+    if (process.env.NODE_ENV === "development") {
       console.info(
         `formatSilkTitle skipped unformatted title: ${continuousTitle}`
       );
     }
-    // Return the input unchanged if no conditions are met
+
     return continuousTitle;
   }
 
@@ -430,7 +461,7 @@ export default function PlayerPage() {
           {mergedData.map((item, index) => {
             return (
               <li
-                key={item.id || index}
+                key={`${item.continuous_vimeo_id}:${item.start_time}:${item.real_vimeo_video_id}`}
                 role="listitem"
                 onClick={(event) => handleChapterClick(item, index, event)}
                 className={`${styles.chapterItem} ${

--- a/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
@@ -206,30 +206,62 @@ export default function PlayerPage() {
     }
   }, [activeChapterIndex, isDesktop]);
 
-  // 1. Build a map of thumbnails using real_vimeo_video_id
+  // Check for duplicate real_vimeo_video_id in videoThumbnails
+  useEffect(() => {
+    if (!videoThumbnails.length) return;
+
+    const counts = new Map<string, number>();
+    for (const v of videoThumbnails) {
+      const key = String(v.real_vimeo_video_id ?? "");
+      if (!key) continue;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const dups = Array.from(counts.entries()).filter(([, n]) => n > 1);
+    if (dups.length) {
+      console.warn(
+        "[PlayerPage] Duplicate real_vimeo_video_id(s) in videoThumbnails:",
+        dups
+      );
+      console.warn(
+        "[PlayerPage] Example duplicated rows:",
+        videoThumbnails.filter(
+          (v) => String(v.real_vimeo_video_id) === dups[0][0]
+        )
+      );
+    }
+  }, [videoThumbnails]);
+
+  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
   const thumbnailMap = new Map<string, VideoThumbnails>();
   videoThumbnails.forEach((item) => {
-    if (item.real_vimeo_video_id) {
-      thumbnailMap.set(item.real_vimeo_video_id, item);
+    if (item?.real_vimeo_video_id) {
+      thumbnailMap.set(String(item.real_vimeo_video_id), item);
     }
   });
 
-  //  Merge chapters with thumbnails
-  const mergedData = chapters.map((chapter, index) => {
-    const meta = videoThumbnails[index] || {};
+  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
+  const mergedData: VideoItem[] = chapters.map((chapter) => {
+    const meta = chapter.real_vimeo_video_id
+      ? thumbnailMap.get(String(chapter.real_vimeo_video_id))
+      : undefined;
+
     return {
       ...chapter,
-      ...meta,
-      video_description:
-        meta.video_description ||
-        continuousVideo.video_description || // Get from continuousVideo if not in chapter
-        "",
-      title: chapter.title || meta.corresponding_video_title || "Untitled",
+      ...(meta ?? {}),
+      title: chapter.title || meta?.corresponding_video_title || "Untitled",
       thumbnail_url: meta?.thumbnail_url?.startsWith("http")
         ? meta.thumbnail_url
         : "/assets/images/default-thumbnail.jpg",
-      real_vimeo_video_id:
-        chapter.real_vimeo_video_id || meta.real_vimeo_video_id,
+      video_description:
+        meta?.video_description || continuousVideo.video_description || "",
+      real_vimeo_video_id: String(
+        chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
+      ),
+      chapter_id: meta?.chapter_id ?? "",
+      chapter_title: meta?.chapter_title ?? "",
+      corresponding_video_title: meta?.corresponding_video_title ?? "",
+      created_at: meta?.created_at ?? "",
     };
   });
 

--- a/src/app/api/chapters/route.ts
+++ b/src/app/api/chapters/route.ts
@@ -33,9 +33,8 @@ export async function GET(req: Request): Promise<NextResponse> {
       [continuousVimeoId]
     );
 
-    const chapters = rows as Chapter[];
-
-    return NextResponse.json(chapters, { status: 200 });
+    // Return raw DB rows (no dedupe)
+    return NextResponse.json(rows as Chapter[], { status: 200 });
   } catch (error) {
     console.error("❌ Error fetching chapters:", error);
     return NextResponse.json(

--- a/src/app/api/continuous-videos/[id]/route.ts
+++ b/src/app/api/continuous-videos/[id]/route.ts
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
       WHERE continuous_vimeo_id = ?
         AND title NOT LIKE '%warmup%'
         AND title NOT LIKE '%cooldown%'
-      ORDER BY id ASC
+      ORDER BY start_time ASC
     `,
       [continuousVideoId]
     );


### PR DESCRIPTION
Documentation Notes — Player chapter selection fix + API ordering cleanup
Summary / Why we changed this
Users were seeing incorrect behavior in the continuous Vimeo player chapter list (ex: clicking “Round 5” would highlight it briefly and then snap back to “Round 4”, and/or thumbnails/titles appeared mismatched). The root causes were:

Unstable data merging between:
/api/chapters?continuous_vimeo_id=... (chapter timing + ids)
/api/continuous-videos/[id] (thumbnail/metadata “chapter rows”)
The UI previously relied on array index alignment (or “implicit ordering”) between these two responses. When DB rows were inserted out of order (e.g., chapter with a later [id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) but earlier/later [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)), that index-based merge could bind the wrong metadata to a chapter.

Vimeo timeupdate callback stale closure The timeupdate handler was reading an older [mergedData](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) array captured at the time the player was initialized. If [mergedData](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) changes later (as API requests resolve), the handler can compute the “current chapter index” using stale boundaries and overwrite the correct highlight after a click.

Console noise / unhandled promise rejection During rapid navigation/unmount, Vimeo player calls can throw [Unknown player. Probably unloaded.](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) which may appear as unhandled promise rejections in production console.

Files changed (high level)
1) [page.tsx](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Goal: Make chapter selection and chapter metadata deterministic and resilient to DB row ordering changes.

A) Merge chapter + metadata by stable key ([real_vimeo_video_id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html))
We introduced a stable join using [real_vimeo_video_id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), instead of relying on “chapter list index lines up with thumbnails list index”.

Build a lookup map from [videoThumbnails](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html):

Normalize join keys with [String(...).trim()](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to avoid number/string mismatch and whitespace issues.

This ensures:

Chapters render with the correct thumbnail/title/description even if the DB insertion order changes.
We are not dependent on [id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) ordering.
B) Sort chapters by [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) before rendering
[mergedData](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) sorts [chapters](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) by [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) so chapter list and boundary detection reflect how the video plays.

This ensures:

The chapter list is in playback order.
Time-based boundary detection works reliably.
C) Prevent Vimeo timeupdate from using stale data
We added:

[mergedDataRef](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) ([useRef<VideoItem[]>](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) which is kept in sync with the latest computed [mergedData](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
The Vimeo timeupdate callback reads from [mergedDataRef.current](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Why:

React closures mean the handler can close over an old [mergedData](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Using a ref guarantees the handler always sees the newest chapter boundaries.
D) Reduce “snap back” on click by seeking slightly past the exact boundary
When a user clicks a chapter, we seek to:

[chapter.start_time + 0.01](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Why:

Some players/events can land exactly on the boundary and immediately resolve to the previous segment depending on rounding/frame timing.
The epsilon avoids boundary ambiguity.
E) Harden player lifecycle to avoid “Unknown player. Probably unloaded.”
We adjusted the Vimeo setup effect to:

Track [isMounted](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Catch [player.ready()](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) errors and ignore the specific unload/unknown-player condition
Unregister the timeupdate listener on cleanup
Catch [destroy()](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) errors and ignore the same unload condition
This avoids noisy/unhelpful console errors during navigation/unmount.

F) Clean up dev-only logging
[formatSilkTitle](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) previously logged based on NEXT_PUBLIC_APP_URL, which could be unreliable across environments. We gated it to:

[process.env.NODE_ENV === "development"](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
So:

No console spam in production
Still useful while developing
2) [route.ts](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Goal: Stop hiding data issues and keep the API simple/deterministic.

We removed the earlier server-side dedupe workaround and now:

Return raw DB rows as queried
Keep deterministic ordering via ORDER BY start_time ASC
Why:

The UI is now resilient to duplicates/misordering because it uses stable joins + time-based sorting.
Returning raw rows prevents the API from masking underlying DB problems.
3) [route.ts](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Goal: Ensure chapter metadata used for thumbnails is also time-ordered.

Change:

ORDER BY id ASC → ORDER BY start_time ASC
Why:

Chapters should be ordered by playback time, not insertion ID.
This prevents inconsistent ordering between endpoints and reduces risk of subtle UI misalignment.
Behavioral changes / What should be true now
After these changes:

Clicking a chapter always seeks to the correct time (based on that chapter’s [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)), and the correct chapter remains active.

Thumbnails/titles/descriptions match the correct chapter, because we merge with metadata using [real_vimeo_video_id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) rather than array index.

The “active chapter” highlighting follows playback time reliably, because time boundaries are computed from [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) and the handler always reads the latest chapter list.

Fewer noisy console errors from the Vimeo player during unmount/navigation.

Validation steps (recommended checklist)
Local sanity checks
Open a continuous playlist (e.g., Lower Body Bands).
Click multiple rounds out of order (Round 5 → Round 2 → Round 10).
Confirm:
The player seeks to that round’s segment.
The UI highlight does not snap back.
The correct thumbnail/title renders for the active chapter.
Network/API validation
Verify /api/chapters?continuous_vimeo_id=... returns rows ordered by [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Verify /api/continuous-videos/[id] returns chapters ordered by [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Console
Confirm no repeated “Unknown player. Probably unloaded.” errors during normal navigation.
Confirm [formatSilkTitle](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) logs only in dev.
Notes / Implementation details for future maintainers
Join key: [real_vimeo_video_id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is treated as the canonical stable key between chapter timing rows and chapter metadata rows.
ID is not authoritative for order: [id](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) may reflect insertion order, not playback. Always prefer [start_time](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) for ordering and boundary computations.
Ref-based event handler pattern: For long-lived event listeners (timeupdate), use a ref ([mergedDataRef](vscode-file://vscode-app/private/var/folders/5c/0z7vvbjn2pj1y8wx1182wjrh0000gn/T/AppTranslocation/62FD27CD-5114-45B9-993E-6927FC1944EF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) rather than capturing dynamic data in a closure.
Player boundary epsilon: + 0.01 is intentional to prevent boundary classification issues.
Keep API transparent: prefer returning raw DB rows unless there’s a strictly documented reason to transform/dedupe server-side.