### PR TITLE
Fix check/update db (DB updated to include missing videos CC Rd. 9 and LLB Rd. 4) / Upate Next.js to stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "jsonwebtoken": "^9.0.2",
         "micro": "^10.0.1",
         "mysql2": "^3.12.0",
-        "next": "^15.1.5",
+        "next": "^15.5.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
@@ -36,7 +36,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.1.5",
+        "eslint-config-next": "^15.5.9",
         "typescript": "^5"
       }
     },
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
-      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -351,13 +351,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
-      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -373,13 +373,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.3"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
-      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
-      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
-      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
       ],
@@ -456,10 +456,26 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
-      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -473,9 +489,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
-      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -489,9 +505,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
-      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -505,9 +521,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
-      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -521,9 +537,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
-      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -539,13 +555,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.3"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
-      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -561,13 +577,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.3"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
-      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
       ],
@@ -583,13 +599,35 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
-      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -605,13 +643,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.3"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
-      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -627,13 +665,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.3"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
-      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -649,13 +687,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
-      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -671,20 +709,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
-      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.5.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -694,9 +732,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
-      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
       ],
@@ -713,9 +751,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
-      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -732,9 +770,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
-      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -768,15 +806,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.5.tgz",
-      "integrity": "sha512-2Zhvss36s/yL+YSxD5ZL5dz5pI6ki1OLxYlh6O77VJ68sBnlUrl5YqhBgCy7FkdMsp9RBeGFwpuDCdpJOqdKeQ==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.1.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.1.5.tgz",
-      "integrity": "sha512-3cCrXBybsqe94UxD6DBQCYCCiP9YohBMgZ5IzzPYHmPzj8oqNlhBii5b6o1HDDaRHdz2pVnSsAROCtrczy8O0g==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.9.tgz",
+      "integrity": "sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -784,9 +822,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.5.tgz",
-      "integrity": "sha512-lYExGHuFIHeOxf40mRLWoA84iY2sLELB23BV5FIDHhdJkN1LpRTPc1MDOawgTo5ifbM5dvAwnGuHyNm60G1+jw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "cpu": [
         "arm64"
       ],
@@ -800,9 +838,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.5.tgz",
-      "integrity": "sha512-cacs/WQqa96IhqUm+7CY+z/0j9sW6X80KE07v3IAJuv+z0UNvJtKSlT/T1w1SpaQRa9l0wCYYZlRZUhUOvEVmg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "cpu": [
         "x64"
       ],
@@ -816,9 +854,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.5.tgz",
-      "integrity": "sha512-tLd90SvkRFik6LSfuYjcJEmwqcNEnVYVOyKTacSazya/SLlSwy/VYKsDE4GIzOBd+h3gW+FXqShc2XBavccHCg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "cpu": [
         "arm64"
       ],
@@ -832,9 +870,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.5.tgz",
-      "integrity": "sha512-ekV76G2R/l3nkvylkfy9jBSYHeB4QcJ7LdDseT6INnn1p51bmDS1eGoSoq+RxfQ7B1wt+Qa0pIl5aqcx0GLpbw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "cpu": [
         "arm64"
       ],
@@ -848,9 +886,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.5.tgz",
-      "integrity": "sha512-tI+sBu+3FmWtqlqD4xKJcj3KJtqbniLombKTE7/UWyyoHmOyAo3aZ7QcEHIOgInXOG1nt0rwh0KGmNbvSB0Djg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "cpu": [
         "x64"
       ],
@@ -864,9 +902,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.5.tgz",
-      "integrity": "sha512-kDRh+epN/ulroNJLr+toDjN+/JClY5L+OAWjOrrKCI0qcKvTw9GBx7CU/rdA2bgi4WpZN3l0rf/3+b8rduEwrQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "cpu": [
         "x64"
       ],
@@ -880,9 +918,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.5.tgz",
-      "integrity": "sha512-GDgdNPFFqiKjTrmfw01sMMRWhVN5wOCmFzPloxa7ksDfX6TZt62tAK986f0ZYqWpvDFqeBCLAzmgTURvtQBdgw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "cpu": [
         "arm64"
       ],
@@ -896,9 +934,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.5.tgz",
-      "integrity": "sha512-5kE3oRJxc7M8RmcTANP8RGoJkaYlwIiDD92gSwCjJY0+j8w8Sl1lvxgQ3bxfHY2KkHFai9tpy/Qx1saWV8eaJQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "cpu": [
         "x64"
       ],
@@ -2838,13 +2876,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.1.5.tgz",
-      "integrity": "sha512-Awm7iUJY8toOR+fU8yTxZnA7/LyOGUGOd6cENCuDfJ3gucHOSmLdOSGJ4u+nlrs8p5qXemua42bZmq+uOzxl6Q==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.9.tgz",
+      "integrity": "sha512-852JYI3NkFNzW8CqsMhI0K2CDRxTObdZ2jQJj5CtpEaOkYHn13107tHpNuD/h0WRpU4FAbCdUaxQsrfBtNK9Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.1.5",
+        "@next/eslint-plugin-next": "15.5.9",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -3513,9 +3551,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4345,9 +4383,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4430,23 +4468,23 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4784,12 +4822,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.5.tgz",
-      "integrity": "sha512-OQVdBPtpBfq7HxFN0kOVb7rXXOSIkt5lTzDJDGRBcOyVvNRIWFauMqi1gIHd1pszq1542vMOGY0HP4CaiALfkA==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.5",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4802,14 +4840,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.5",
-        "@next/swc-darwin-x64": "15.5.5",
-        "@next/swc-linux-arm64-gnu": "15.5.5",
-        "@next/swc-linux-arm64-musl": "15.5.5",
-        "@next/swc-linux-x64-gnu": "15.5.5",
-        "@next/swc-linux-x64-musl": "15.5.5",
-        "@next/swc-win32-arm64-msvc": "15.5.5",
-        "@next/swc-win32-x64-msvc": "15.5.5",
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -5237,9 +5275,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5696,16 +5734,16 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
-      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.0",
-        "semver": "^7.7.2"
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -5714,28 +5752,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.4",
-        "@img/sharp-darwin-x64": "0.34.4",
-        "@img/sharp-libvips-darwin-arm64": "1.2.3",
-        "@img/sharp-libvips-darwin-x64": "1.2.3",
-        "@img/sharp-libvips-linux-arm": "1.2.3",
-        "@img/sharp-libvips-linux-arm64": "1.2.3",
-        "@img/sharp-libvips-linux-ppc64": "1.2.3",
-        "@img/sharp-libvips-linux-s390x": "1.2.3",
-        "@img/sharp-libvips-linux-x64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
-        "@img/sharp-linux-arm": "0.34.4",
-        "@img/sharp-linux-arm64": "0.34.4",
-        "@img/sharp-linux-ppc64": "0.34.4",
-        "@img/sharp-linux-s390x": "0.34.4",
-        "@img/sharp-linux-x64": "0.34.4",
-        "@img/sharp-linuxmusl-arm64": "0.34.4",
-        "@img/sharp-linuxmusl-x64": "0.34.4",
-        "@img/sharp-wasm32": "0.34.4",
-        "@img/sharp-win32-arm64": "0.34.4",
-        "@img/sharp-win32-ia32": "0.34.4",
-        "@img/sharp-win32-x64": "0.34.4"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/sharp/node_modules/detect-libc": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "^9.0.2",
     "micro": "^10.0.1",
     "mysql2": "^3.12.0",
-    "next": "^15.1.5",
+    "next": "^15.5.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
@@ -37,7 +37,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.1.5",
+    "eslint-config-next": "^15.5.9",
     "typescript": "^5"
   }
 }

--- a/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { useSearchParams, useParams, useRouter } from "next/navigation";
 import backArrowIcon from "/public/assets/icons/arrow-left.svg";
 import Player from "@vimeo/player";
@@ -43,6 +43,7 @@ export default function PlayerPage() {
     ? parseInt(searchParams.get("start_time") as string, 10)
     : 0;
   const autoplay = searchParams.get("autoplay") === "1";
+
   const [continuousVideo, setContinuousVideo] = useState({
     continuous_video_id: "",
     continuous_video_title: "",
@@ -58,6 +59,52 @@ export default function PlayerPage() {
 
   const playerContainerRef = useRef<HTMLDivElement | null>(null);
   const vimeoPlayerRef = useRef<Player | null>(null);
+
+  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
+  const thumbnailMap = useMemo(() => {
+    const m = new Map<string, VideoThumbnails>();
+    videoThumbnails.forEach((item) => {
+      const key = String(item?.real_vimeo_video_id ?? "").trim();
+      if (key) m.set(key, item);
+    });
+    return m;
+  }, [videoThumbnails]);
+
+  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
+  const mergedData: VideoItem[] = useMemo(() => {
+    return chapters
+      .slice()
+      .sort((a, b) => a.start_time - b.start_time)
+      .map((chapter) => {
+        const chapterKey = String(chapter.real_vimeo_video_id ?? "").trim();
+        const meta = chapterKey ? thumbnailMap.get(chapterKey) : undefined;
+
+        return {
+          ...chapter,
+          ...(meta ?? {}),
+          id: chapter.id, // prevent meta.id from overwriting chapters.id
+          title: chapter.title || meta?.corresponding_video_title || "Untitled",
+          thumbnail_url: meta?.thumbnail_url?.startsWith("http")
+            ? meta.thumbnail_url
+            : "/assets/images/default-thumbnail.jpg",
+          video_description:
+            meta?.video_description || continuousVideo.video_description || "",
+          real_vimeo_video_id: String(
+            chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
+          ).trim(),
+          chapter_id: meta?.chapter_id ?? "",
+          chapter_title: meta?.chapter_title ?? "",
+          corresponding_video_title: meta?.corresponding_video_title ?? "",
+          created_at: meta?.created_at ?? "",
+        };
+      });
+  }, [chapters, thumbnailMap, continuousVideo.video_description]);
+
+  // Keep latest mergedData accessible to the Vimeo event handler (avoid stale closure)
+  const mergedDataRef = useRef<VideoItem[]>([]);
+  useEffect(() => {
+    mergedDataRef.current = mergedData;
+  }, [mergedData]);
 
   //Check if the screen is a desktop
   useEffect(() => {
@@ -93,7 +140,7 @@ export default function PlayerPage() {
       }
     }
     fetchData();
-  }, [continuous_vimeo_id]);
+  }, [continuous_vimeo_id, router]);
 
   //  Fetch video thumbnails
   useEffect(() => {
@@ -120,6 +167,8 @@ export default function PlayerPage() {
   useEffect(() => {
     if (!playerContainerRef.current || vimeoPlayerRef.current) return;
 
+    let isMounted = true;
+
     const player = new Player(playerContainerRef.current, {
       id: parseInt(continuous_vimeo_id, 10),
       responsive: true,
@@ -128,30 +177,64 @@ export default function PlayerPage() {
 
     vimeoPlayerRef.current = player;
 
-    player.ready().then(async () => {
-      setPlayerReady(true);
-      if (initialStartTime > 0) {
-        await player.setCurrentTime(initialStartTime).catch(console.error);
-        try {
-          await player.play();
-        } catch (err) {
-          console.warn("Autoplay blocked (expected in some browsers):", err);
-        }
-      }
+    const onTimeUpdate = (data: { seconds: number }) => {
+      const list = mergedDataRef.current;
+      if (!list.length) return;
 
-      player.on("timeupdate", (data) => {
-        const currentTime = data.seconds;
-        const index =
-          chapters.filter((c) => c.start_time <= currentTime).length - 1;
-        if (index !== activeChapterIndex) setActiveChapterIndex(index);
+      const t = data.seconds;
+
+      let idx = list.findIndex((c, i) => {
+        const start = c.start_time;
+        const nextStart = list[i + 1]?.start_time ?? Number.POSITIVE_INFINITY;
+        return t >= start && t < nextStart;
       });
-    });
+
+      if (idx === -1) idx = 0;
+      setActiveChapterIndex((prev) => (prev === idx ? prev : idx));
+    };
+
+    player
+      .ready()
+      .then(async () => {
+        if (!isMounted) return;
+
+        setPlayerReady(true);
+
+        if (initialStartTime > 0) {
+          await player.setCurrentTime(initialStartTime).catch(console.error);
+          try {
+            await player.play();
+          } catch (err) {
+            console.warn("Autoplay blocked (expected in some browsers):", err);
+          }
+        }
+
+        player.on("timeupdate", onTimeUpdate);
+      })
+      .catch((err) => {
+        const msg = String(err?.message ?? err);
+        if (msg.includes("Unknown player") || msg.includes("unloaded")) return;
+        console.error("Vimeo player ready() failed:", err);
+      });
 
     return () => {
-      player.destroy().catch(console.error);
+      isMounted = false;
+
+      try {
+        player.off("timeupdate", onTimeUpdate);
+      } catch {
+        // ignore
+      }
+
+      player.destroy().catch((err) => {
+        const msg = String(err?.message ?? err);
+        if (msg.includes("Unknown player") || msg.includes("unloaded")) return;
+        console.error(err);
+      });
+
       vimeoPlayerRef.current = null;
     };
-  }, [continuous_vimeo_id, chapters, initialStartTime]);
+  }, [continuous_vimeo_id, initialStartTime]);
 
   //  Autoplay logic
   useEffect(() => {
@@ -166,7 +249,7 @@ export default function PlayerPage() {
         console.warn("Autoplay blocked by browser:", err);
       });
     }
-  }, [autoplay, playerReady, chapters]);
+  }, [autoplay, playerReady, chapters, initialStartTime]);
 
   //  Clean up injected Vimeo styles
   useEffect(() => {
@@ -194,8 +277,8 @@ export default function PlayerPage() {
   useEffect(() => {
     if (
       isDesktop &&
-      activeChapterIndex &&
-      activeChapterIndex > -1 &&
+      typeof activeChapterIndex === "number" &&
+      activeChapterIndex >= 0 &&
       scrollableContainerRef.current
     ) {
       const activeChapter = Array.from(
@@ -206,66 +289,9 @@ export default function PlayerPage() {
     }
   }, [activeChapterIndex, isDesktop]);
 
-  // Check for duplicate real_vimeo_video_id in videoThumbnails
-  useEffect(() => {
-    if (!videoThumbnails.length) return;
+  // NOTE: removed debug-only duplicate logging for production cleanliness
 
-    const counts = new Map<string, number>();
-    for (const v of videoThumbnails) {
-      const key = String(v.real_vimeo_video_id ?? "");
-      if (!key) continue;
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-
-    const dups = Array.from(counts.entries()).filter(([, n]) => n > 1);
-    if (dups.length) {
-      console.warn(
-        "[PlayerPage] Duplicate real_vimeo_video_id(s) in videoThumbnails:",
-        dups
-      );
-      console.warn(
-        "[PlayerPage] Example duplicated rows:",
-        videoThumbnails.filter(
-          (v) => String(v.real_vimeo_video_id) === dups[0][0]
-        )
-      );
-    }
-  }, [videoThumbnails]);
-
-  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
-  const thumbnailMap = new Map<string, VideoThumbnails>();
-  videoThumbnails.forEach((item) => {
-    if (item?.real_vimeo_video_id) {
-      thumbnailMap.set(String(item.real_vimeo_video_id), item);
-    }
-  });
-
-  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
-  const mergedData: VideoItem[] = chapters.map((chapter) => {
-    const meta = chapter.real_vimeo_video_id
-      ? thumbnailMap.get(String(chapter.real_vimeo_video_id))
-      : undefined;
-
-    return {
-      ...chapter,
-      ...(meta ?? {}),
-      title: chapter.title || meta?.corresponding_video_title || "Untitled",
-      thumbnail_url: meta?.thumbnail_url?.startsWith("http")
-        ? meta.thumbnail_url
-        : "/assets/images/default-thumbnail.jpg",
-      video_description:
-        meta?.video_description || continuousVideo.video_description || "",
-      real_vimeo_video_id: String(
-        chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
-      ),
-      chapter_id: meta?.chapter_id ?? "",
-      chapter_title: meta?.chapter_title ?? "",
-      corresponding_video_title: meta?.corresponding_video_title ?? "",
-      created_at: meta?.created_at ?? "",
-    };
-  });
-
-  const handleChapterClick = (
+  const handleChapterClick = async (
     chapter: VideoItem,
     index: number,
     event: React.MouseEvent<HTMLLIElement>
@@ -279,13 +305,22 @@ export default function PlayerPage() {
       return;
     }
 
-    if (vimeoPlayerRef.current) {
-      vimeoPlayerRef.current.setCurrentTime(chapter.start_time).then(() => {
-        vimeoPlayerRef.current?.play().catch((err) => {
-          console.warn("Autoplay blocked on chapter click:", err);
-        });
-        setActiveChapterIndex(index);
+    const player = vimeoPlayerRef.current;
+    if (!player) return;
+
+    // Optimistically set highlight immediately
+    setActiveChapterIndex(index);
+
+    try {
+      // Nudge forward by a tiny epsilon so boundary conditions won't snap to prior chapter
+      const target = Math.max(0, Number(chapter.start_time) + 0.01);
+      await player.setCurrentTime(target);
+
+      player.play().catch((err) => {
+        console.warn("Autoplay blocked on chapter click:", err);
       });
+    } catch (e) {
+      console.error("Failed to seek to chapter:", e);
     }
   };
 
@@ -308,15 +343,12 @@ export default function PlayerPage() {
       fifteen: "15",
     };
 
-    // Normalize the input by trimming and converting to lowercase
     const normalizedTitle = continuousTitle.trim().toLowerCase();
 
-    // Check for 'Silk Continuous' using lowercase comparison
     if (normalizedTitle.includes("silk continuous")) {
       return continuousTitle.replace(/silk continuous/i, "").trim();
     }
 
-    // Check for 'Silk Workout' using lowercase comparison
     if (normalizedTitle.includes("silk workout")) {
       const words = continuousTitle
         .replace(/silk workout/i, "")
@@ -331,13 +363,12 @@ export default function PlayerPage() {
       return `100% Prescription Program ${words.join(" ")}`;
     }
 
-    // log in non production mode, title that don't need formatting
-    if (process.env.NEXT_PUBLIC_APP_URL !== "https://systemofsilk.com") {
+    if (process.env.NODE_ENV === "development") {
       console.info(
         `formatSilkTitle skipped unformatted title: ${continuousTitle}`
       );
     }
-    // Return the input unchanged if no conditions are met
+
     return continuousTitle;
   }
 
@@ -430,7 +461,7 @@ export default function PlayerPage() {
           {mergedData.map((item, index) => {
             return (
               <li
-                key={item.id || index}
+                key={`${item.continuous_vimeo_id}:${item.start_time}:${item.real_vimeo_video_id}`}
                 role="listitem"
                 onClick={(event) => handleChapterClick(item, index, event)}
                 className={`${styles.chapterItem} ${

--- a/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/player/[continuous_vimeo_id]/page.tsx
@@ -206,30 +206,62 @@ export default function PlayerPage() {
     }
   }, [activeChapterIndex, isDesktop]);
 
-  // 1. Build a map of thumbnails using real_vimeo_video_id
+  // Check for duplicate real_vimeo_video_id in videoThumbnails
+  useEffect(() => {
+    if (!videoThumbnails.length) return;
+
+    const counts = new Map<string, number>();
+    for (const v of videoThumbnails) {
+      const key = String(v.real_vimeo_video_id ?? "");
+      if (!key) continue;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const dups = Array.from(counts.entries()).filter(([, n]) => n > 1);
+    if (dups.length) {
+      console.warn(
+        "[PlayerPage] Duplicate real_vimeo_video_id(s) in videoThumbnails:",
+        dups
+      );
+      console.warn(
+        "[PlayerPage] Example duplicated rows:",
+        videoThumbnails.filter(
+          (v) => String(v.real_vimeo_video_id) === dups[0][0]
+        )
+      );
+    }
+  }, [videoThumbnails]);
+
+  // Build thumbnail lookup by real_vimeo_video_id (stable join key)
   const thumbnailMap = new Map<string, VideoThumbnails>();
   videoThumbnails.forEach((item) => {
-    if (item.real_vimeo_video_id) {
-      thumbnailMap.set(item.real_vimeo_video_id, item);
+    if (item?.real_vimeo_video_id) {
+      thumbnailMap.set(String(item.real_vimeo_video_id), item);
     }
   });
 
-  //  Merge chapters with thumbnails
-  const mergedData = chapters.map((chapter, index) => {
-    const meta = videoThumbnails[index] || {};
+  // Merge chapters with thumbnails/descriptions by real_vimeo_video_id (NOT array index)
+  const mergedData: VideoItem[] = chapters.map((chapter) => {
+    const meta = chapter.real_vimeo_video_id
+      ? thumbnailMap.get(String(chapter.real_vimeo_video_id))
+      : undefined;
+
     return {
       ...chapter,
-      ...meta,
-      video_description:
-        meta.video_description ||
-        continuousVideo.video_description || // Get from continuousVideo if not in chapter
-        "",
-      title: chapter.title || meta.corresponding_video_title || "Untitled",
+      ...(meta ?? {}),
+      title: chapter.title || meta?.corresponding_video_title || "Untitled",
       thumbnail_url: meta?.thumbnail_url?.startsWith("http")
         ? meta.thumbnail_url
         : "/assets/images/default-thumbnail.jpg",
-      real_vimeo_video_id:
-        chapter.real_vimeo_video_id || meta.real_vimeo_video_id,
+      video_description:
+        meta?.video_description || continuousVideo.video_description || "",
+      real_vimeo_video_id: String(
+        chapter.real_vimeo_video_id || meta?.real_vimeo_video_id || ""
+      ),
+      chapter_id: meta?.chapter_id ?? "",
+      chapter_title: meta?.chapter_title ?? "",
+      corresponding_video_title: meta?.corresponding_video_title ?? "",
+      created_at: meta?.created_at ?? "",
     };
   });
 

--- a/src/app/api/chapters/route.ts
+++ b/src/app/api/chapters/route.ts
@@ -33,9 +33,8 @@ export async function GET(req: Request): Promise<NextResponse> {
       [continuousVimeoId]
     );
 
-    const chapters = rows as Chapter[];
-
-    return NextResponse.json(chapters, { status: 200 });
+    // Return raw DB rows (no dedupe)
+    return NextResponse.json(rows as Chapter[], { status: 200 });
   } catch (error) {
     console.error("❌ Error fetching chapters:", error);
     return NextResponse.json(

--- a/src/app/api/continuous-videos/[id]/route.ts
+++ b/src/app/api/continuous-videos/[id]/route.ts
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
       WHERE continuous_vimeo_id = ?
         AND title NOT LIKE '%warmup%'
         AND title NOT LIKE '%cooldown%'
-      ORDER BY id ASC
+      ORDER BY start_time ASC
     `,
       [continuousVideoId]
     );


### PR DESCRIPTION
1. ocumentation Notes — Player chapter selection fix + API ordering cleanup
Summary / Why we changed this
Users were seeing incorrect behavior in the continuous Vimeo player chapter list (ex: clicking “Round 5” would highlight it briefly and then snap back to “Round 4”, and/or thumbnails/titles appeared mismatched). The root causes were:

Unstable data merging between:
/api/chapters?continuous_vimeo_id=... (chapter timing + ids)
/api/continuous-videos/[id] (thumbnail/metadata “chapter rows”)
The UI previously relied on array index alignment (or “implicit ordering”) between these two responses. When DB rows were inserted out of order (e.g., chapter with a later id but earlier/later start_time), that index-based merge could bind the wrong metadata to a chapter.

Vimeo timeupdate callback stale closure The timeupdate handler was reading an older mergedData array captured at the time the player was initialized. If mergedData changes later (as API requests resolve), the handler can compute the “current chapter index” using stale boundaries and overwrite the correct highlight after a click.

Console noise / unhandled promise rejection During rapid navigation/unmount, Vimeo player calls can throw Unknown player. Probably unloaded. which may appear as unhandled promise rejections in production console.

Files changed (high level)

page.tsx
Goal: Make chapter selection and chapter metadata deterministic and resilient to DB row ordering changes.
A) Merge chapter + metadata by stable key (real_vimeo_video_id)
We introduced a stable join using real_vimeo_video_id, instead of relying on “chapter list index lines up with thumbnails list index”.

Build a lookup map from videoThumbnails:

Normalize join keys with String(...).trim() to avoid number/string mismatch and whitespace issues.

This ensures:

Chapters render with the correct thumbnail/title/description even if the DB insertion order changes.
We are not dependent on id ordering.
B) Sort chapters by start_time before rendering
mergedData sorts chapters by start_time so chapter list and boundary detection reflect how the video plays.

This ensures:

The chapter list is in playback order.
Time-based boundary detection works reliably.
C) Prevent Vimeo timeupdate from using stale data
We added:

mergedDataRef (useRef<VideoItem[]>) which is kept in sync with the latest computed mergedData.
The Vimeo timeupdate callback reads from mergedDataRef.current.
Why:

React closures mean the handler can close over an old mergedData.
Using a ref guarantees the handler always sees the newest chapter boundaries.
D) Reduce “snap back” on click by seeking slightly past the exact boundary
When a user clicks a chapter, we seek to:

chapter.start_time + 0.01
Why:

Some players/events can land exactly on the boundary and immediately resolve to the previous segment depending on rounding/frame timing.
The epsilon avoids boundary ambiguity.
E) Harden player lifecycle to avoid “Unknown player. Probably unloaded.”
We adjusted the Vimeo setup effect to:

Track isMounted
Catch player.ready() errors and ignore the specific unload/unknown-player condition
Unregister the timeupdate listener on cleanup
Catch destroy() errors and ignore the same unload condition
This avoids noisy/unhelpful console errors during navigation/unmount.

F) Clean up dev-only logging
formatSilkTitle previously logged based on NEXT_PUBLIC_APP_URL, which could be unreliable across environments. We gated it to:

process.env.NODE_ENV === "development"
So:

No console spam in production
Still useful while developing
2) route.ts
Goal: Stop hiding data issues and keep the API simple/deterministic.

We removed the earlier server-side dedupe workaround and now:

Return raw DB rows as queried
Keep deterministic ordering via ORDER BY start_time ASC
Why:

The UI is now resilient to duplicates/misordering because it uses stable joins + time-based sorting.
Returning raw rows prevents the API from masking underlying DB problems.
3) route.ts
Goal: Ensure chapter metadata used for thumbnails is also time-ordered.

Change:

ORDER BY id ASC → ORDER BY start_time ASC
Why:

Chapters should be ordered by playback time, not insertion ID.
This prevents inconsistent ordering between endpoints and reduces risk of subtle UI misalignment.
Behavioral changes / What should be true now
After these changes:

Clicking a chapter always seeks to the correct time (based on that chapter’s start_time), and the correct chapter remains active.

Thumbnails/titles/descriptions match the correct chapter, because we merge with metadata using real_vimeo_video_id rather than array index.

The “active chapter” highlighting follows playback time reliably, because time boundaries are computed from start_time and the handler always reads the latest chapter list.

Fewer noisy console errors from the Vimeo player during unmount/navigation.

Validation steps (recommended checklist)
Local sanity checks
Open a continuous playlist (e.g., Lower Body Bands).
Click multiple rounds out of order (Round 5 → Round 2 → Round 10).
Confirm:
The player seeks to that round’s segment.
The UI highlight does not snap back.
The correct thumbnail/title renders for the active chapter.
Network/API validation
Verify /api/chapters?continuous_vimeo_id=... returns rows ordered by start_time.
Verify /api/continuous-videos/[id] returns chapters ordered by start_time.
Console
Confirm no repeated “Unknown player. Probably unloaded.” errors during normal navigation.
Confirm formatSilkTitle logs only in dev.
Notes / Implementation details for future maintainers
Join key: real_vimeo_video_id is treated as the canonical stable key between chapter timing rows and chapter metadata rows.
ID is not authoritative for order: id may reflect insertion order, not playback. Always prefer start_time for ordering and boundary computations.
Ref-based event handler pattern: For long-lived event listeners (timeupdate), use a ref (mergedDataRef) rather than capturing dynamic data in a closure.
Player boundary epsilon: + 0.01 is intentional to prevent boundary classification issues.
Keep API transparent: prefer returning raw DB rows unless there’s a strictly documented reason to transform/dedupe server-side.

2. This PR upgrades the frontend to a patched Next.js release to resolve Vercel’s security block and clear npm audit.

What changed
Bumped Next.js to ^15.5.9
Bumped eslint-config-next to ^15.5.9 (kept in sync with Next)
Updated package-lock.json via a clean install (npm ci) to ensure deterministic dependencies
Why
Vercel deployment was blocked due to an identified Next.js vulnerability (CVE/security advisory).
After this update:
npm audit reports 0 vulnerabilities
npm run build succeeds
Verification
npm ci
npm run build (successful)
npm audit → found 0 vulnerabilities
Notes
crypto@1.0.1 shows a deprecation warning (Node has built-in crypto). This PR does not remove it; can be handled in a follow-up cleanup PR.